### PR TITLE
Publish releases using Azure Pipelines

### DIFF
--- a/SayIt/SayIt.fsproj
+++ b/SayIt/SayIt.fsproj
@@ -5,15 +5,6 @@
         <TargetFramework>netcoreapp3.0</TargetFramework>
     </PropertyGroup>
 
-    <!-- <PropertyGroup>
-        <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
-        <PublishSingleFile>true</PublishSingleFile>
-        <PublishTrimmed>true</PublishTrimmed> -->
-
-        <!-- this increases size and reduces startup time -->
-        <!-- <PublishReadyToRun>true</PublishReadyToRun>
-    </PropertyGroup>-->
-
     <ItemGroup>
         <Compile Include="Config.fs" />
         <Compile Include="Program.fs" />

--- a/SayIt/SayIt.fsproj
+++ b/SayIt/SayIt.fsproj
@@ -5,14 +5,14 @@
         <TargetFramework>netcoreapp3.0</TargetFramework>
     </PropertyGroup>
 
-    <PropertyGroup>
+    <!-- <PropertyGroup>
         <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
         <PublishSingleFile>true</PublishSingleFile>
-        <PublishTrimmed>true</PublishTrimmed>
+        <PublishTrimmed>true</PublishTrimmed> -->
 
         <!-- this increases size and reduces startup time -->
-        <PublishReadyToRun>true</PublishReadyToRun>
-    </PropertyGroup>
+        <!-- <PublishReadyToRun>true</PublishReadyToRun>
+    </PropertyGroup>-->
 
     <ItemGroup>
         <Compile Include="Config.fs" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,10 +21,11 @@ pool:
 
 variables:
   buildConfiguration: 'Release'
+  framework: netcoreapp3.0
 
 steps:
 - task: UseDotNet@2
-  displayName: 'Install .NET Core SDK'
+  displayName: Install .NET Core SDK
   inputs:
     version: 3.0.100
 
@@ -36,7 +37,24 @@ steps:
     arguments: '--configuration $(buildConfiguration)'
 
 - task: DotNetCoreCLI@2
+  displayName: Run tests
   inputs:
     command: test
     projects: '**/*Tests/*.fsproj'
-    arguments: '--configuration $(buildConfiguration) --collect "Code coverage"'
+    arguments: '--configuration $(buildConfiguration) --collect:"XPlat Code coverage"'
+
+- task: DotNetCoreCLI@2
+  displayName: Install ReportGenerator tool
+  inputs:
+    command: custom
+    custom: tool
+    arguments: install --tool-path . dotnet-reportgenerator-globaltool
+
+- script: reportgenerator -reports:$(Agent.TempDirectory)/**/coverage.cobertura.xml -targetdir:$(Build.SourcesDirectory)/coverlet/reports -reporttypes:"Cobertura"
+  displayName: Create reports
+
+- task: PublishCodeCoverageResults@1
+  displayName: Publish code coverage
+  inputs:
+    codeCoverageTool: Cobertura
+    summaryFileLocation: $(Build.SourcesDirectory)/coverlet/reports/Cobertura.xml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ steps:
     custom: tool
     arguments: install --tool-path . dotnet-reportgenerator-globaltool
 
-- script: reportgenerator -reports:$(Agent.TempDirectory)/**/coverage.cobertura.xml -targetdir:$(Build.SourcesDirectory)/coverlet/reports -reporttypes:"Cobertura"
+- script: ./reportgenerator -reports:$(Agent.TempDirectory)/**/coverage.cobertura.xml -targetdir:$(Build.SourcesDirectory)/coverlet/reports -reporttypes:"Cobertura"
   displayName: Create reports
 
 - task: PublishCodeCoverageResults@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,10 +11,13 @@ strategy:
   matrix:
     Linux:
       imageName: 'ubuntu-latest'
+      rid: 'linux-x64'
     Mac:
       imageName: 'macos-latest'
+      rid: 'osx-x64'
     Windows:
       imageName: 'vs2017-win2016'
+      rid: 'win-x64'
 
 pool:
   vmImage: $(imageName)
@@ -49,7 +52,7 @@ steps:
     command: publish
     publishWebProjects: False
     projects: 'SayIt/SayIt.fsproj'
-    arguments: '-c $(BuildConfiguration) -f $(framework) /p:PublishSingleFile=true /p:PublishReadyToRun=true /p:UseAppHost=true --output $(Build.ArtifactStagingDirectory)'
+    arguments: '-c $(BuildConfiguration) -f $(framework) /p:RuntimeIdentifier=$(rid) /p:PublishSingleFile=true /p:PublishReadyToRun=true /p:UseAppHost=true --output $(Build.ArtifactStagingDirectory)'
 
 - task: PublishBuildArtifacts@1
   displayName: Publish artifact

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,27 +34,23 @@ steps:
   inputs:
     command: build
     projects: '**/*.fsproj'
-    arguments: '--configuration $(buildConfiguration)'
+    arguments: '-c $(buildConfiguration)'
 
 - task: DotNetCoreCLI@2
   displayName: Run tests
   inputs:
     command: test
     projects: '**/*Tests/*.fsproj'
-    arguments: '--configuration $(buildConfiguration) --collect:"XPlat Code coverage"'
+    arguments: '-c $(buildConfiguration)'
 
 - task: DotNetCoreCLI@2
-  displayName: Install ReportGenerator tool
   inputs:
-    command: custom
-    custom: tool
-    arguments: install --tool-path . dotnet-reportgenerator-globaltool
+    command: publish
+    publishWebProjects: True
+    arguments: '-c $(BuildConfiguration) -f $(framework) /p:PublishSingleFile=true /p:PublishReadyToRun=true /p:UseAppHost=true --output $(Build.ArtifactStagingDirectory)'
+    zipAfterPublish: True
 
-- script: ./reportgenerator -reports:$(Agent.TempDirectory)/**/coverage.cobertura.xml -targetdir:$(Build.SourcesDirectory)/coverlet/reports -reporttypes:"Cobertura"
-  displayName: Create reports
-
-- task: PublishCodeCoverageResults@1
-  displayName: Publish code coverage
+- task: PublishBuildArtifacts@1
   inputs:
-    codeCoverageTool: Cobertura
-    summaryFileLocation: $(Build.SourcesDirectory)/coverlet/reports/Cobertura.xml
+    pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+    artifactName: 'sayit'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,9 +46,7 @@ steps:
 - task: DotNetCoreCLI@2
   inputs:
     command: publish
-    publishWebProjects: True
     arguments: '-c $(BuildConfiguration) -f $(framework) /p:PublishSingleFile=true /p:PublishReadyToRun=true /p:UseAppHost=true --output $(Build.ArtifactStagingDirectory)'
-    zipAfterPublish: True
 
 - task: PublishBuildArtifacts@1
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,12 +44,15 @@ steps:
     arguments: '-c $(buildConfiguration)'
 
 - task: DotNetCoreCLI@2
+  displayName: Publish release
   inputs:
     command: publish
-    projects: '**/SayIt.fsproj'
+    publishWebProjects: False
+    projects: 'SayIt/SayIt.fsproj'
     arguments: '-c $(BuildConfiguration) -f $(framework) /p:PublishSingleFile=true /p:PublishReadyToRun=true /p:UseAppHost=true --output $(Build.ArtifactStagingDirectory)'
 
 - task: PublishBuildArtifacts@1
+  displayName: Publish artifact
   inputs:
     pathtoPublish: '$(Build.ArtifactStagingDirectory)'
     artifactName: 'sayit'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,12 +12,15 @@ strategy:
     Linux:
       imageName: 'ubuntu-latest'
       rid: 'linux-x64'
+      artifact: 'sayit-linux-x64'
     Mac:
       imageName: 'macos-latest'
       rid: 'osx-x64'
+      artifact: 'sayit-osx-x64'
     Windows:
       imageName: 'vs2017-win2016'
       rid: 'win-x64'
+      artifact: 'sayit-win-x64'
 
 pool:
   vmImage: $(imageName)
@@ -58,4 +61,4 @@ steps:
   displayName: Publish artifact
   inputs:
     pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-    artifactName: 'sayit'
+    artifactName: '$(artifact)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,6 +46,7 @@ steps:
 - task: DotNetCoreCLI@2
   inputs:
     command: publish
+    projects: '**/SayIt.fsproj'
     arguments: '-c $(BuildConfiguration) -f $(framework) /p:PublishSingleFile=true /p:PublishReadyToRun=true /p:UseAppHost=true --output $(Build.ArtifactStagingDirectory)'
 
 - task: PublishBuildArtifacts@1


### PR DESCRIPTION
- [x] ~~publish code coverage~~ can't be done [as in these docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/ecosystems/dotnet-core?view=azure-devops#collect-code-coverage-metrics-with-coverlet) on the 3 platforms 'cause it fails on Windows as in [this build](https://dev.azure.com/pviotti/gh-pipelines/_build/results?buildId=67&view=logs&j=022b0a5d-2698-5f72-7610-a845972a8b4c&t=fb4a47ce-9e3e-59af-1bc9-5f0d015ee903&l=16)
- [x] publish self-contained release for Linux-x64, Win-x64 and MacOS-x64
- [x] automate GitHub release creation