### PR TITLE
Fix GH Action builds

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -46,7 +46,6 @@ jobs:
       run: |
         export SHA=${GITHUB_SHA:0:7}
         dotnet publish -c Debug -o ./sayit-dev-$SHA
-        echo ::set-env name=SHA::"${GITHUB_SHA:0:7}"
 
     - name: Upload debug artifact
       uses: actions/upload-artifact@v1.0.0

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -46,6 +46,7 @@ jobs:
       run: |
         export SHA=${GITHUB_SHA:0:7}
         dotnet publish -c Debug -o ./sayit-dev-$SHA
+        echo SHA=${GITHUB_SHA:0:7} >> $GITHUB_ENV
 
     - name: Upload debug artifact
       uses: actions/upload-artifact@v1.0.0


### PR DESCRIPTION
Remove instructions to set environment variables to avoid vulnerability - https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/