### PR TITLE
GitHub Actions: remove PublishReadyToRun for non-linux targets

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -63,9 +63,9 @@ jobs:
         dotnet publish -c Release -r win-x64 --self-contained false -o ./sayit-$VERSION-win
         dotnet publish -c Release -r linux-x64 --self-contained false -o ./sayit-$VERSION-linux
         dotnet publish -c Release -r osx-x64 --self-contained false -o ./sayit-$VERSION-osx
-        dotnet publish -c Release -r win-x64 -p:PublishSingleFile=true -p:PublishReadyToRun=true -o ./sayit-$VERSION-win-sc
+        dotnet publish -c Release -r win-x64 -p:PublishSingleFile=true -o ./sayit-$VERSION-win-sc
         dotnet publish -c Release -r linux-x64 -p:PublishSingleFile=true -p:PublishReadyToRun=true -o ./sayit-$VERSION-linux-sc
-        dotnet publish -c Release -r osx-x64 -p:PublishSingleFile=true -p:PublishReadyToRun=true -o ./sayit-$VERSION-osx-sc
+        dotnet publish -c Release -r osx-x64 -p:PublishSingleFile=true -o ./sayit-$VERSION-osx-sc
 
         zip -r sayit-$VERSION-win.zip sayit-$VERSION-win
         zip -r sayit-$VERSION-linux.zip sayit-$VERSION-linux


### PR DESCRIPTION
Remove PublishReadyToRun for non-linux publish targets because that feature has some restrictions on cross-platform compilation https://docs.microsoft.com/en-us/dotnet/core/deploying/ready-to-run#cross-platformarchitecture-restrictions

Note: there are [workarounds](https://github.com/actions/create-release/issues/14), but they're fairly convoluted and would entail giving up the automated draft release creation - so: no, sorry, Mac/Windows users.